### PR TITLE
오류 수정

### DIFF
--- a/app/src/main/java/kr/dori/android/own_cast/HomeFragment.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/HomeFragment.kt
@@ -104,6 +104,8 @@ class HomeFragment : Fragment() {
 
         binding.insertKeyw.setOnClickListener {//검색창 이동
             val intent = Intent(getActivity(), KeywordActivity::class.java)
+            intent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+
             stopAudio() // 음원 중단
             intent.putExtra("isSearch",true)
             startActivity(intent)
@@ -120,6 +122,7 @@ class HomeFragment : Fragment() {
         binding.homefrScriptDirectInputTv.setOnClickListener {
             val intent = Intent(getActivity(), KeywordActivity::class.java)
             intent.putExtra("isSearch",false)
+            intent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
             stopAudio() // 음원 중단
             activityResultLauncher.launch(intent)
         }
@@ -147,6 +150,7 @@ class HomeFragment : Fragment() {
 
                 textList[i].setOnClickListener {
                     val intent = Intent(getActivity(), KeywordActivity::class.java)
+                    intent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
                     intent.putExtra("searchText",textList[i].text.toString())
                     stopAudio() // 음원 중단
                     startActivity(intent)

--- a/app/src/main/java/kr/dori/android/own_cast/forApiData/AuthResponse.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/forApiData/AuthResponse.kt
@@ -37,7 +37,8 @@ data class AuthResponse<T> (
 data class ErrorResponse (
     @SerializedName(value = "isSuccess") val isSuccess: Boolean,
     @SerializedName(value = "code") val code: String,
-    @SerializedName(value = "message") val message: String?
+    @SerializedName(value = "message") val message: String?,
+    @SerializedName(value = "result") val result: String?
 )
 
 // 2 계층

--- a/app/src/main/java/kr/dori/android/own_cast/forApiData/AuthRetrofitInterface.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/forApiData/AuthRetrofitInterface.kt
@@ -120,7 +120,8 @@ interface Playlist{
     suspend fun getMy(): Response<AuthResponse<GetPlayList>>
 
     @DELETE("/api/playlist/{playlistId}")
-    suspend fun deleteOtherCast(@Path("playlistId") playlistId:Long,@Body deleteOtherDto: DeleteOtherDto ):Response<AuthResponse<DeleteOther>>
+    fun deleteOtherCast(@Path("playlistId") playlistId:Long,
+                        @Query("castId") castId: Long):Call<AuthResponse<DeleteOther>>
 }
 
 

--- a/app/src/main/java/kr/dori/android/own_cast/keyword/KeyvpAudioSaveFragment.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/keyword/KeyvpAudioSaveFragment.kt
@@ -359,7 +359,7 @@ override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     //finish dialog listener 구현
     override fun goHomeFragment() {
         super.goHomeFragment()
-        activity?.supportFragmentManager?.popBackStackImmediate(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        //activity?.supportFragmentManager?.popBackStackImmediate(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
         activity?.finish()
     }
         //캐스트 이동
@@ -429,7 +429,7 @@ override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     }
 
 
-
+    //캐스트 저장
     fun postCastSave(){//api저장하는 버튼
         val apiService = getRetrofit().create(CastInterface::class.java)
         //1. apiService후, 자신이 만들어놓은 인터페이스(함수 지정해주기)
@@ -539,6 +539,8 @@ override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
         })
     }
+
+    //바로 들으러 가기
     fun getCastInfo(playlistId: Long) {
         val getAllPlaylist = getRetrofit().create(Playlist::class.java)
         val dialog = KeywordLoadingDialog(requireContext(),"이동 중입니다.")
@@ -547,7 +549,7 @@ override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         dialog.show()
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                val response = getAllPlaylist.getPlaylistInfo(playlistId, 0, 5)
+                val response = getAllPlaylist.getPlaylistInfo(playlistId, 0, 20)
                 withContext(Dispatchers.Main) { dialog.dismiss() }
                 if (response.isSuccessful) {
                     val playlistInfo = response.body()?.result
@@ -569,16 +571,11 @@ override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
                                     imagePath = cast.imagePath
                                 )
                             }
-
-                            CastPlayerData.setCast(castListWithPlaylistId, castListWithPlaylistId.size-1)
+                            Log.d("캐스트 저장", castListWithPlaylistId.toString())
+                            CastPlayerData.setCast(castListWithPlaylistId, 0)
                             CastPlayerData.setCurrentIndex(castListWithPlaylistId.size-1)
                             ToPlayCast(castListWithPlaylistId)
-                            // 캐스트 리스트를 저장
-                            //괜히 id쓰는것보다 어차피 마지막 가있을테니깐 넣었음..
-                            //CastPlayerData.currentPosition = CastPlayerData.getAllCastList().size -1
-                            //CastPlayerData.currentCast = CastPlayerData.getAllCastList()[CastPlayerData.currentPosition]
-                            //val intent = Intent(activity, PlayCastActivity::class.java)
-                            //startActivity(intent)
+
                             activity?.finish()
                             finDialog.dismiss()
                         }

--- a/app/src/main/java/kr/dori/android/own_cast/keyword/KeyvpAudioSetFragment.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/keyword/KeyvpAudioSetFragment.kt
@@ -94,8 +94,8 @@ class KeyvpAudioSetFragment() : Fragment(), CoroutineScope {
         binding.keywordAudiosetSb.setOnSeekBarChangeListener(object :
             SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
-                if (progress < 1) {
-                    seekBar?.progress = 1
+                if (progress < 2) {
+                    seekBar?.progress = 2
                 } else if (progress % 2 == 0) {
                     audioTime = progress*30
                     binding.keyAudSetCurTimeTv.text = "${progress / 2}분"

--- a/app/src/main/java/kr/dori/android/own_cast/player/CastWithPlaylistId.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/player/CastWithPlaylistId.kt
@@ -6,7 +6,7 @@ import java.io.Serializable
 
 data class CastWithPlaylistId(
     val castId: Long,
-    val playlistId: Long,
+    var playlistId: Long,
     val castTitle: String,
     val isPublic: Boolean,
     val castCreator: String,

--- a/app/src/main/java/kr/dori/android/own_cast/playlist/AddCategoryAdapter.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/playlist/AddCategoryAdapter.kt
@@ -75,10 +75,10 @@ class AddCategoryAdapter(val context: Context, private val mover: SearchMover) :
                 binding.categoryImg.setImageBitmap(bitmap)
             }
             binding.categoryItemAll.setOnClickListener {
-                if(id!=(-1L)){
+                if(id>=0){
                     saveOtherCast(id,data.playlistId)
                 }else{
-                    Toast.makeText(context," 캐스트아이디 오류",Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context,"캐스트아이디 오류",Toast.LENGTH_SHORT).show()
                 }
 
             }
@@ -99,6 +99,7 @@ class AddCategoryAdapter(val context: Context, private val mover: SearchMover) :
                         dialog.dismiss()
                         if(response.isSuccessful){
                             Toast.makeText(context,"저장 성공",Toast.LENGTH_SHORT).show()
+                            CastPlayerData.currentCast.playlistId =playlistId
                         }
                         else{
                             response.errorBody()?.let { errorBody ->

--- a/app/src/main/java/kr/dori/android/own_cast/playlist/CastFragment.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/playlist/CastFragment.kt
@@ -32,7 +32,7 @@ import kr.dori.android.own_cast.keyword.KeywordLoadingDialog
 import kr.dori.android.own_cast.player.CastWithPlaylistId
 
 
-class CastFragment(var playlistIdList: MutableList<Long>) : Fragment(), ActivityMover {
+class CastFragment() : Fragment(), ActivityMover {
     private lateinit var binding: FragmentCastBinding
     private lateinit var castAdapter: CastAdapter
     private lateinit var activityResultLauncher: ActivityResultLauncher<Intent>
@@ -61,7 +61,7 @@ class CastFragment(var playlistIdList: MutableList<Long>) : Fragment(), Activity
         loadingdialog.show()
         CoroutineScope(Dispatchers.Main).launch {
             try {
-                if (isSave) {
+                if (!isSave) {
                     val response = getPlaylist.getSaved()
                     Log.d("CastFragment", "getSaved API 호출")
                     if (response.isSuccessful) {

--- a/app/src/main/java/kr/dori/android/own_cast/playlist/PlaylistFragment.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/playlist/PlaylistFragment.kt
@@ -77,7 +77,7 @@ class PlaylistFragment : Fragment(), AddCategoryListener, EditCategoryListener, 
             val bundle = Bundle().apply {
                 putBoolean("isSave", true)  // 세이브 버튼 클릭 시 true 전달
             }
-            val castFragment = CastFragment(playlistIdList).apply {
+            val castFragment = CastFragment().apply {
                 arguments = bundle
             }
             requireActivity().supportFragmentManager.beginTransaction()
@@ -90,7 +90,7 @@ class PlaylistFragment : Fragment(), AddCategoryListener, EditCategoryListener, 
             val bundle = Bundle().apply {
                 putBoolean("isSave", false)  // 세이브 버튼 클릭 시 true 전달
             }
-            val castFragment = CastFragment(playlistIdList).apply {
+            val castFragment = CastFragment().apply {
                 arguments = bundle
             }
             requireActivity().supportFragmentManager.beginTransaction()

--- a/app/src/main/java/kr/dori/android/own_cast/search/SearchAdapter.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/search/SearchAdapter.kt
@@ -50,7 +50,7 @@ class SearchAdapter(private val mover: SearchMover) : RecyclerView.Adapter<Searc
             binding.searchfrItemDurationTv.text = data.audioLength
 
             binding.searchfrItemAddCategoryOffIv.setOnClickListener {
-                mover.goAddCast(data.id)
+                mover.goAddCast(data)
             }
             binding.itemThumbIv.setOnClickListener {
                 mover.goPlayCast(dataList,data.id)

--- a/app/src/main/java/kr/dori/android/own_cast/search/SearchAddCategoryActivity.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/search/SearchAddCategoryActivity.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kr.dori.android.own_cast.R
+import kr.dori.android.own_cast.data.CastPlayerData
 import kr.dori.android.own_cast.databinding.ActivitySearchAddCategoryBinding
 import kr.dori.android.own_cast.forApiData.CastHomeDTO
 import kr.dori.android.own_cast.forApiData.CastInterface
@@ -39,29 +40,13 @@ class SearchAddCategoryActivity : AppCompatActivity(), SearchMover {
 
         binding = ActivitySearchAddCategoryBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        val playlist = intent.getSerializableExtra("categoryList") as? ArrayList<GetAllPlaylist>?
-        val id = intent.getLongExtra("id",-1)
 
 
-        if(!playlist.isNullOrEmpty()){
-            //내가 만든거 담아온거 없애야 돼서
-            playlist.removeAt(0)
-            playlist.removeAt(0)
-            searchadapter = AddCategoryAdapter(this,this)
-            searchadapter.dataList = playlist
-            binding.activitySearchAddCategoryRv.adapter = searchadapter
-            binding.activitySearchAddCategoryRv.layoutManager = LinearLayoutManager(this)
-            if(playlist.isNullOrEmpty()){
-                Toast.makeText(this,"재생목록이 비어있습니다.",Toast.LENGTH_SHORT).show()
-            }
-        }else {
-            initCategoryData()//이 함수에서 아래 내용 해줄거임
-            /*binding.activitySearchAddCategoryRv.adapter = searchadapter
-            binding.activitySearchAddCategoryRv.layoutManager = LinearLayoutManager(this)*/
-        }
-        id?.let {
-            searchadapter.id = it
-        }
+        //add해야되는 부분이 검색과 플레이 캐스트 액티비티이므로, 차라리 currentCast받아오게 변경
+        searchadapter = AddCategoryAdapter(this,this)
+        initCategoryData()//재생목록 받아온다
+
+
 
 
         binding.activitySearchAddCategoryExitIv.setOnClickListener {
@@ -73,12 +58,11 @@ class SearchAddCategoryActivity : AppCompatActivity(), SearchMover {
         TODO("Not yet implemented")
     }
 
-    override fun goAddCast(id:Long) {
+    override fun goAddCast(castHomeDTO: CastHomeDTO) {
         TODO("Not yet implemented")
     }
 
     override fun backSearch() {
-
         finish()
     }
 
@@ -101,7 +85,8 @@ class SearchAddCategoryActivity : AppCompatActivity(), SearchMover {
 
     fun initCategoryData(){
         val getCategory = getRetrofit().create(PlayListInterface::class.java)
-        val loadingDialog = KeywordLoadingDialog(this,"데이터를 불러오고 있어요")
+        val loadingDialog = KeywordLoadingDialog(this,"재생목록을 불러오고 있어요")
+        Log.d("캐스트 추가", "함수 진입")
         loadingDialog.setCancelable(false)
         loadingDialog.setCanceledOnTouchOutside(false)
         loadingDialog.show()
@@ -121,23 +106,26 @@ class SearchAddCategoryActivity : AppCompatActivity(), SearchMover {
                                         totalCast = it.totalCast
                                     )
                                 }
+                                //추가할때도 검색한 캐스트를 currentCast로 설정해버림
+
+                                searchadapter.id = CastPlayerData.currentCast.castId
                                 searchadapter.dataList.addAll(data)
                                 searchadapter.dataList.removeAt(0)
                                 searchadapter.dataList.removeAt(0)
                                 binding.activitySearchAddCategoryRv.adapter = searchadapter
                                 binding.activitySearchAddCategoryRv.layoutManager = LinearLayoutManager(this@SearchAddCategoryActivity)
-                                Log.d("카테고리 추가","성공 \n ${data.toString()}")
+                                Log.d("캐스트 추가","성공 \n ${data.toString()}")
                             }
                         } else {
+                            Log.d("캐스트 추가","실패 ${response.code()}")
                             Toast.makeText(this@SearchAddCategoryActivity,"재생목록 불러오기 실패,\n 오류코드 : $${response.code()}",Toast.LENGTH_SHORT).show()
                         }
 
                     } catch (e: Exception) {
+                        Log.d("캐스트 추가","실패 ${e.message}")
                         e.printStackTrace()
                     }
                 }
-
-
             }
         }
     }

--- a/app/src/main/java/kr/dori/android/own_cast/search/SearchFragment.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/search/SearchFragment.kt
@@ -93,7 +93,7 @@ class SearchFragment : Fragment(), SearchMover, ActivityMover {
 
         val getAllPlaylist = getRetrofit().create(Playlist::class.java)
 
-        CoroutineScope(Dispatchers.IO).launch() {
+        /*CoroutineScope(Dispatchers.IO).launch() {
             launch {
                 try {
                     val response =
@@ -116,7 +116,7 @@ class SearchFragment : Fragment(), SearchMover, ActivityMover {
             }
 
 
-        }
+        }*/
 
 
         if(SignupData.interest.equals("self")){
@@ -173,20 +173,31 @@ class SearchFragment : Fragment(), SearchMover, ActivityMover {
                 imagePath = it.imagePath
             )
         }
-        var imageData = list.map{
-            it.imagePath
-        }
+
         CastPlayerData.setCast(data,1)//데이터 초기화
         ToPlayCast(data)
-    //    CastPlayerData.setCurrentPos(id)//
+        CastPlayerData.setCurrentPos(id)
 
 
     }
 
-    override fun goAddCast(id:Long) {//여기다가 카테고리 정보 담아야함
+    override fun goAddCast(castHomeDTO: CastHomeDTO) {//여기다가 카테고리 정보 담아야함
         val intent = Intent(requireContext(), SearchAddCategoryActivity::class.java)
-        sharedViewModel.data.value?.let{
+        /*sharedViewModel.data.value?.let{
             intent.putExtra("categoryList",ArrayList(it))
+        }*/
+
+        CastPlayerData.currentCast = castHomeDTO.let{
+            CastWithPlaylistId(
+                castId = it.id,
+                playlistId = -1L,
+                castTitle = it.playlistName,
+                isPublic = true,
+                castCreator = it.memberName,
+                castCategory = it.memberName,
+                audioLength = it.audioLength,
+                imagePath = it.imagePath
+            )
         }
         intent.putExtra("id",id)
         startActivity(intent)
@@ -203,6 +214,7 @@ class SearchFragment : Fragment(), SearchMover, ActivityMover {
 
                 if(response.isSuccessful) {
                     val resp: AuthResponse<List<CastHomeDTO>> = response.body()!!
+
                     resp.result?.let {
                         //왜 오류처리가 안될까?
                         setItemData(it)
@@ -251,8 +263,6 @@ class SearchFragment : Fragment(), SearchMover, ActivityMover {
             categoryTv.text = "${castHomeDTO[i].memberName}-${castHomeDTO[i].playlistName}"
             Log.d("searchFragment_apicheck","${castHomeDTO[i].audioLength}")
             durationTv.text = castHomeDTO[i].audioLength
-
-
             if (castHomeDTO[i].imagePath.startsWith("http")) {
                 // URL로부터 이미지 로드 (Glide 사용)
                 Glide.with(itemView.context)
@@ -270,7 +280,8 @@ class SearchFragment : Fragment(), SearchMover, ActivityMover {
             }
             val addCtgOffBtn = itemView.findViewById<ImageView>(R.id.searchfr_item_add_category_off_iv)
             addCtgOffBtn.setOnClickListener {
-                goAddCast(castHomeDTO[i].id)
+                Log.d("검색 프래그먼트 id","${castHomeDTO[i].id}")
+                goAddCast(castHomeDTO[i])
             }
 
             binding.gridLayout.addView(itemView)

--- a/app/src/main/java/kr/dori/android/own_cast/search/SearchMover.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/search/SearchMover.kt
@@ -5,7 +5,7 @@ import kr.dori.android.own_cast.forApiData.CastHomeDTO
 interface SearchMover {
     fun goPlayCast(list: List<CastHomeDTO>, id:Long)
 
-    fun goAddCast(id:Long)
+    fun goAddCast( castHomeDTO: CastHomeDTO)
 
     fun backSearch()
 }

--- a/app/src/main/java/kr/dori/android/own_cast/search/SearchOutputFragment.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/search/SearchOutputFragment.kt
@@ -120,17 +120,28 @@ class SearchOutputFragment : Fragment(), SearchMover , CoroutineScope, ActivityM
                 imagePath = it.imagePath
             )
         }
-        var imageData = list.map{
-            it.imagePath
-        }
+
         CastPlayerData.setCast(data,1)//데이터 초기화
+        CastPlayerData.setCurrentPos(id)
         ToPlayCast(data)
     }
 
-    override fun goAddCast(id : Long) {
+    override fun goAddCast(castHomeDTO: CastHomeDTO) {
         val intent = Intent(requireContext(), SearchAddCategoryActivity::class.java)
-        sharedViewModel.data.value?.let{
+        /*sharedViewModel.data.value?.let{
             intent.putExtra("categoryList",ArrayList(it))
+        }*/
+        CastPlayerData.currentCast = castHomeDTO.let{
+            CastWithPlaylistId(
+                castId = it.id,
+                playlistId = 0L,
+                castTitle = it.playlistName,
+                isPublic = true,
+                castCreator = it.memberName,
+                castCategory = it.memberName,
+                audioLength = it.audioLength,
+                imagePath = it.imagePath
+            )
         }
         intent.putExtra("id",id)
         startActivity(intent)

--- a/app/src/main/java/kr/dori/android/own_cast/search/SearchTwoAdapter.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/search/SearchTwoAdapter.kt
@@ -50,7 +50,7 @@ class SearchTwoAdapter(private val mover: SearchMover) : RecyclerView.Adapter<Se
             binding.searchDurationTv.text = data.audioLength
             binding.searchAddCategoryOffIv.setOnClickListener {
 
-                mover.goAddCast(data.id)
+                mover.goAddCast(data)
             }
             binding.searchPlayIv.setOnClickListener {
 

--- a/app/src/main/java/kr/dori/android/own_cast/search/SearchTwoFragment.kt
+++ b/app/src/main/java/kr/dori/android/own_cast/search/SearchTwoFragment.kt
@@ -162,14 +162,27 @@ class SearchTwoFragment:Fragment(), SearchMover, CoroutineScope,ActivityMover {
         }
 
         CastPlayerData.setCast(data,1)//데이터 초기화
+        CastPlayerData.setCurrentPos(id)
         ToPlayCast(data)
     }
 
-    override fun goAddCast(id:Long) {//여기다가 카테고리 정보 담아야함
+    override fun goAddCast(castHomeDTO:CastHomeDTO) {//여기다가 카테고리 정보 담아야함
         val intent = Intent(requireContext(), SearchAddCategoryActivity::class.java)
-        sharedViewModel.data.value?.let{
+        /*sharedViewModel.data.value?.let{
 
             intent.putExtra("categoryList",ArrayList(it))
+        }*/
+        CastPlayerData.currentCast = castHomeDTO.let{
+            CastWithPlaylistId(
+                castId = it.id,
+                playlistId = 0L,
+                castTitle = it.playlistName,
+                isPublic = true,
+                castCreator = it.memberName,
+                castCategory = it.memberName,
+                audioLength = it.audioLength,
+                imagePath = it.imagePath
+            )
         }
         intent.putExtra("id",id)
         startActivity(intent)

--- a/app/src/main/res/layout/fragment_cast_playlist.xml
+++ b/app/src/main/res/layout/fragment_cast_playlist.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:background="#FFFFFF"
-    android:layout_height="540dp">
+    android:layout_height="match_parent">
 
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/fragment_keyvp_audiosave.xml
+++ b/app/src/main/res/layout/fragment_keyvp_audiosave.xml
@@ -56,6 +56,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:ems="10"
+        android:maxLength="20"
         app:layout_constraintWidth_percent="0.911111111"
         android:hint="제목"
 


### PR DESCRIPTION
1. 캐스트 생성 후, 종료시 바로 종료 안되는 점 -> 해결(플래그 관리로 이상한 것들이 너무 많이 들어가서 오히려 안된거같음)
2. 바로 들으러 가기에서 플리정보를 받아오면 최근에 추가한 캐스트가 바로 반영이 안됨->해결(플리를 받아오면서 size제한을 5로 뒀는데 20으로 늘리니 또 그만큼 불러와져서 size에 대해 내일 물어보기)
4. 남의 캐스트 플리 추가 삭제 재 구현(구현하면서 로직 예원이한테 물어보고, 백한테 요청해야할 수도)->삭제쪽 서버 함수 다시 하고 확인할듯

fix. 검색 프래그먼트에서 addCategory로 이동하는 부분에서 currentCast로 id를 받아오게 설정 addCategory에서 그냥 api 호출해가지구 카테고리 받아오게 했음

fix. CastFragment에서 커스텀 프래그먼트처럼 변수 받구 있는 부분이 오류가 나서 지웠음(코드내에서도 안쓰길래 지움)
CastFragment(변수 : 변수) 이렇게 된거